### PR TITLE
Transition to `main` default branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,9 @@ If you have questions or want to propose changes to this document, feel free to 
     2. [Suggesting Enhancements](#suggesting-enhancements)
     3. [Contributing Code](#contributing-code)
  4. [Additional Software](#additional-software)
- 5. [Directory Structure](#directory-structure)
+ 5. [Repository Structure](#repository-structure)
+    1. [Branch Names](#branch-names)
+    2. [Directory Structure](#directory-structure)
  6. [Testing](#testing)
     1. [Running Unit Tests](#running-unit-tests)
     2. [Writing Unit Tests](#writing-unit-tests)
@@ -133,11 +135,11 @@ The following instructions guide you through the creation of a pull request and 
        git clone git@github.com:<YOUR_USER_NAME>/<REPOSITORY>.git
        ```
 
-       In a forked repository, you can push to the master branch directly.
+       In a forked repository, you can push to the `main` branch directly.
        Consider enabling GitHub actions on the Actions tab of your fork of the repository to run the CI pipeline before you create a pull request.
 
      - Members of the FreeProving project do don't have to fork repositories they want to contribute to.
-       In the main repository pushing to the master branch is prohibited.
+       In the main repository pushing to the `main` branch is prohibited.
        All development takes place in so called *feature branches*.
        If you are working on a specific issue `#N`, create a branch `issue-N` for all changes related to that issue.
 
@@ -160,12 +162,12 @@ The following instructions guide you through the creation of a pull request and 
     - Ensure that your changes work correctly and do not break other parts of the compiler by running [unit tests and other checks](#testing) frequently.
       You should also [write your own unit tests](#writing-unit-tests).
 
-    - Pull in the master branch regularly to avoid merge conflicts later down the line.
+    - Pull in the `main` branch regularly to avoid merge conflicts later down the line.
 
-      In a feature branch run the following command to merge the latest changes to the master branch on GitHub with your local (currently checked out) feature branch.
+      In a feature branch run the following command to merge the latest changes to the `main` branch on GitHub with your local (currently checked out) feature branch.
 
       ```bash
-      git pull origin master
+      git pull origin main
       ```
 
       If you are working on a fork, you have to add the original repository as a remote first.
@@ -174,10 +176,10 @@ The following instructions guide you through the creation of a pull request and 
       git remote add upstream git@github.com:FreeProving/<REPOSITORY>.git
       ```
 
-      Now you can run the following command to merge the latest changes to the master branch of the original repository on GitHub with the local clone of your fork.
+      Now you can run the following command to merge the latest changes to the `main` branch of the original repository on GitHub with the local clone of your fork.
 
       ```bash
-      git pull upstream master
+      git pull upstream main
       ```
 
     - When making user-facing or other notable changes, add a short entry to the "unreleased" section of the `CHANGELOG.md`.
@@ -217,13 +219,13 @@ The following instructions guide you through the creation of a pull request and 
     Ping a maintainer in a comment below your pull request, informing them that your pull request can be merged now.
 
     Like reviewers, a project maintainer may still request additional changes.
-    If your branch has diverged far from the master branch, they may ask you to pull in the master branch and resolve potential merge conflicts.
+    If your branch has diverged far from the `main` branch, they may ask you to pull in the `main` branch and resolve potential merge conflicts.
     If they do not have any comments, they merge the pull request.
 
     After merging the pull request, the CI pipeline runs again.
-    However this time the checks are performed against the master branch.
+    However this time the checks are performed against the `main` branch.
     It is not your responsibility anymore to make all checks pass in this final run of the CI pipeline.
-    The maintainers are expected to take immediate action if the CI pipeline fails on the master branch.
+    The maintainers are expected to take immediate action if the CI pipeline fails on the `main` branch.
     As a last resort, they may decide to revert the previously merged pull request.
 
 ## Additional Software
@@ -249,11 +251,43 @@ The versions mentioned above are the versions used by our [CI pipelines](#the-ci
 Both tools must be installed in order to [run the CI pipeline locally](#running-the-pipeline-locally).
 If you are not planning to make changes that involve the CI pipeline (i.e., modify Markdown documentation only), you do not have to install these tools.
 
-## Directory Structure
+## Repository Structure
 
 In this section, we would like to give you a quick overview over the general structure of every repository that is part of the FreeProving project.
 These guidelines standardize the organization of repositories such that you as a contributor can quickly find files you are looking for and confidently decide where to place files you want to add even if you are not familiar with the repository otherwise.
 Repositories that deviate from these guidelines, contain additional top-level directories or want to provide more information on their directory structure should include additional information in their READMEs.
+
+### Branch Names
+
+Branches in the repository should adhere to the following naming conventions.
+
+ - `main`
+
+   The default branch of Git repositories that are part of the FreeProving project are called `main`.
+
+   The `main` branch of a repository should be protected.
+   Only maintainers of the FreeProving project and repository administrators can push to the `main` branch directly.
+   All other changes of the `main` branch are coordinated through pull requests (see also [Contributing Code](#contributing-code)).
+
+ - `dev-*`
+
+   Larger features are developed on feature branches with the `dev-` prefix.
+   The same branch protection rules as for `main` apply to `dev-*` branches (i.e., it is not possible to push to these branches directly).
+   Changes to these branches are coordinated through pull requests as well.
+
+ - `issue-*`
+
+   Small features and bug fixes are developed on feature branches with the `issue-` prefix.
+   The full name of a feature branch that contains changes related to a ticket `#N` should be `issue-N`.
+
+ - `*-tests`
+
+   If only test cases are developed on a feature branch, the branch name should have a `-tests` suffix.
+   The full name of a feature branch that contains the tests for the feature or bug fix developed on `issue-N` should be `issue-N-tests`.
+
+### Directory Structure
+
+The directory structure of the repository should be as follows if not stated otherwise in the repository's README.
 
  - `./`
 
@@ -1175,7 +1209,7 @@ When writing markdown documents adhere to the following style considerations.
 
    ```markdown
     [doc/ModuleInterfaceFileFormat.md]:
-      https://github.com/FreeProving/free-compiler/blob/master/doc/ModuleInterfaceFileFormat.md
+      https://github.com/FreeProving/free-compiler/blob/main/doc/ModuleInterfaceFileFormat.md
       "Module Interface File Format — Free Compiler Documentation"
 
     [wiki/ANSI]:
@@ -1308,7 +1342,7 @@ See the [LICENSE][guidelines/LICENSE] file of the corresponding repository for d
   https://github.com/FreeProving/free-compiler
   "Free Compiler on GitHub"
 [free-compiler/haddock/tests]:
-  https://freeproving.github.io/free-compiler/docs/master/freec-unit-tests/
+  https://freeproving.github.io/free-compiler/docs/main/freec-unit-tests/
   "Free Compiler Test Suite — Haddock Documentation"
 
 [FreeProving/issues]:
@@ -1327,7 +1361,7 @@ See the [LICENSE][guidelines/LICENSE] file of the corresponding repository for d
   https://github.com/search?q=is%3Aopen+is%3Apr+user%3AFreeProving+sort%3Acomments-desc
   "Free Compiler — Pull Requests"
 [FreeProving/pull-requests/submit]:
-  https://github.com/FreeProving/guidelines/blob/master/doc/SubmitPullRequest.md
+  https://github.com/FreeProving/guidelines/blob/main/doc/SubmitPullRequest.md
   "Free Compiler — Pull Requests"
 
 [free-proving-code]:
@@ -1368,13 +1402,13 @@ See the [LICENSE][guidelines/LICENSE] file of the corresponding repository for d
   https://github.com/FreeProving/guidelines
   "FreeProving Guidelines on GitHub"
 [guidelines/CODE_OF_CONDUCT]:
-  https://github.com/FreeProving/guidelines/blob/master/CODE_OF_CONDUCT.md
+  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
   "FreeProving Guidelines — Code of Conduct"
 [guidelines/issues]:
   https://github.com/FreeProving/guidelines/issues
   "FreeProving Guidelines — Issues"
 [guidelines/LICENSE]:
-  https://github.com/FreeProving/guidelines/blob/master/LICENSE
+  https://github.com/FreeProving/guidelines/blob/main/LICENSE
   "FreeProving Guidelines — LICENSE file template"
 [guidelines/pull-requests]:
   https://github.com/FreeProving/guidelines/pulls

--- a/ISSUE_TEMPLATE/bug-report.md
+++ b/ISSUE_TEMPLATE/bug-report.md
@@ -8,7 +8,7 @@ about: Create a report to help us improve
 <!--
   Have you read our Code of Conduct?
   By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
-  https://github.com/FreeProving/guidelines/blob/master/CODE_OF_CONDUCT.md
+  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
 -->
 
 ### Description

--- a/ISSUE_TEMPLATE/feature-request.md
+++ b/ISSUE_TEMPLATE/feature-request.md
@@ -8,7 +8,7 @@ about: Suggest an idea for this project
 <!--
   Have you read our Code of Conduct?
   By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
-  https://github.com/FreeProving/guidelines/blob/master/CODE_OF_CONDUCT.md
+  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
 -->
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following link to the contributing guidelines of the FreeProving project sho
 See the [contributing guidelines][] of the FreeProving project.
 
 [contributing guidelines]:
-  https://github.com/FreeProving/guidelines/blob/master/CONTRIBUTING.md
+  https://github.com/FreeProving/guidelines/blob/main/CONTRIBUTING.md
   "Contributing Guidelines of the FreeProving project"
 ```
 
@@ -28,7 +28,7 @@ The Free Proving project and everyone participating in it is governed by our [Co
 By participating, you are expected to uphold this code.
 
 [CODE_OF_CONDUCT]:
-  https://github.com/FreeProving/guidelines/blob/master/CODE_OF_CONDUCT.md
+  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
   "Code of Conduct of the FreeProving project"
 ```
 
@@ -38,7 +38,7 @@ Include the following comment in every pull request or issue template to make co
 <!--
   Have you read our Code of Conduct?
   By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
-  https://github.com/FreeProving/guidelines/blob/master/CODE_OF_CONDUCT.md
+  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
 -->
 ```
 
@@ -63,5 +63,5 @@ The copyright holders of the individual repositories may differ.
 Some repositories may choose a different license if necessary.
 
 [guidelines/LICENSE]:
-  https://github.com/FreeProving/guidelines/blob/master/LICENSE
+  https://github.com/FreeProving/guidelines/blob/main/LICENSE
   "FreeProving Guidelines — LICENSE file template"

--- a/doc/SubmitPullRequest.md
+++ b/doc/SubmitPullRequest.md
@@ -16,10 +16,10 @@ Without your help, the FreeProving project would not be possible.
 See also our [contributing guidelines][guidelines/CONTRIBUTING] for more information about submitting pull requests and our pull request review and acceptance procedure.
 
 [guidelines/CODE_OF_CONDUCT]:
-  https://github.com/FreeProving/guidelines/blob/master/CODE_OF_CONDUCT.md
+  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
   "FreeProving Guidelines — Code of Conduct"
 [guidelines/CONTRIBUTING]:
-  https://github.com/FreeProving/guidelines/blob/master/CONTRIBUTING.md#contributing-code
+  https://github.com/FreeProving/guidelines/blob/main/CONTRIBUTING.md#contributing-code
   "FreeProving Guidelines — Contributing Guidelines — Contributing Code"
 
 [free-compiler]:


### PR DESCRIPTION
## Description

We should change the default branch of all repositories in the FreeProving organization from `master` to `main`.

## Motivation

The recent *black lives matter* movement has brought attention to the fact that racially charged terms such as the master/slave terminology are widely used throughout the tech industry. For example, as of today, the default branch of many Git repositories, including the repositories of the FreeProving project, is commonly called `master`. In order to avoid slavery references, it has been proposed to change the default branch name for new Git repositories from `master` to `main` by leading tech companies, [including GitHub](https://twitter.com/natfriedman/status/1271253144442253312). First open source projects have [started to transition](https://community.redwoodjs.com/t/transitioning-to-main-default-branch/776) to `main` as their default branch already.
In our [Code of Conduct](https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md) we "pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive and healthy community". Thus, I think that it is our obligation to join the fight against white supremacy, even if it is just by the means of a seemingly trivial change such as renaming the default branch to `main`. If the new name of the default branch makes even a single person feel more welcome, the change will be worth it.

## Tasks

The following steps should be performed in each repository of the FreeProving organization. Create a new issue on the repository and copy the tasks list into the issue description.

 - [x] Create a new branch `main` from the current `master`.
 - [x] Select `main` as the default branch in the repository settings on GitHub.
 - [x] Add branch protection rules for `main` in the repository settings on GitHub.
 - [x] Change the CI pipeline (if any) to run on pushes to `main`.
 - [x] If there are open pull requests, set their target branch to `main`.
 - [x] Update links to the `master` branch such that they point to `main` instead.
 - [x] Finally, delete the `master` branch. If the repository's `master` branch has been referenced in a published paper, keep the `master` branch, delete all files and commit a README that links to the new default branch.